### PR TITLE
Html2Text.convert() fixed against non-string input, version 0.2.1

### DIFF
--- a/lib/html2text.rb
+++ b/lib/html2text.rb
@@ -8,6 +8,7 @@ class Html2Text
   end
 
   def self.convert(html)
+    html = html.to_s
     html = fix_newlines(replace_entities(html))
     doc = Nokogiri::HTML(html)
 

--- a/lib/html2text/version.rb
+++ b/lib/html2text/version.rb
@@ -1,3 +1,3 @@
 class Html2Text
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/spec/html2text_spec.rb
+++ b/spec/html2text_spec.rb
@@ -19,6 +19,27 @@ describe Html2Text do
         expect(text).to eq("hello world")
       end
     end
+
+    context "input value is non-string" do
+      let(:html) { nil }
+      it '(nil)' do
+        expect(text).to eq("")
+      end
+    end
+
+    context "input value is non-string" do
+      let(:html) { 1234 }
+      it "(number)" do
+        expect(text).to eq("1234")
+      end
+    end
+
+    context "input value is non-string" do
+      let(:html) { 1234.5600 }
+      it "(float number)" do
+        expect(text).to eq("1234.56")
+      end
+    end
   end
 
   describe "#remove_leading_and_trailing_whitespace" do


### PR DESCRIPTION
This change improves how the library behaves on non-string input. Fixes issue #2.
Version number is increased to 0.2.1 according semver, as I consider this a bugfix.