### PR TITLE
Fix nil output <a> name attribute conversion

### DIFF
--- a/lib/html2text.rb
+++ b/lib/html2text.rb
@@ -142,8 +142,8 @@ class Html2Text
     end
 
     if href.nil?
-      if !name.nil?
-        output = "[#{output}]"
+      if !name.nil? && output.empty?
+        output = nil
       end
     else
       href = href.to_s


### PR DESCRIPTION
The attribute described(link below) was being converted incorrectly for certain pages I tried.
https://www.w3schools.com/tags/att_a_name.asp

I created this [gist](https://gist.github.com/logwolvy/d11b37e12b8ca3e9fc2ab16073ab7cb4) based on the page I was trying to convert and before fix I was getting -
```ruby
'<a name="sp">&nbsp;&nbsp;</a>' # => [ ]
'<a name="serno">87471742</a>' #> [87471742]
```
I admit this is really badly written non-html5 doc, but I really need to convert this for a project in production. After this fix, these conversions are fine.
Kindly, merge this fix. Thanks!
 