### PR TITLE
Test with Ruby 2.7, cache bundler in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
+cache: bundler
 rvm:
-  - 2.3.4
+  - 2.3
+  - 2.7
 before_install:
   - gem update --system
   - gem install bundler


### PR DESCRIPTION
Adds the latest Ruby version to tests as well to the already existing one (which should pick the latest patch release available on Travis).