### PR TITLE
FIX: Parsing nodes with no name

### DIFF
--- a/lib/html2text.rb
+++ b/lib/html2text.rb
@@ -99,16 +99,20 @@ class Html2Text
 
     output << prefix_whitespace(node)
     output += node.children.map do |child|
-      iterate_over(child)
+      if !child.name.nil?
+        iterate_over(child)
+      end
     end
     output << suffix_whitespace(node)
 
     output = output.compact.join("") || ""
 
-    if node.name.downcase == "a"
-      output = wrap_link(node, output)
-    elsif node.name.downcase == "img"
-      output = image_text(node)
+    if !node.name.nil?
+      if node.name.downcase == "a"
+        output = wrap_link(node, output)
+      elsif node.name.downcase == "img"
+        output = image_text(node)
+      end
     end
 
     return output

--- a/spec/examples/malformed-style.html
+++ b/spec/examples/malformed-style.html
@@ -1,0 +1,52 @@
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <title>title</title>
+</head>
+<body>
+<!DOCTYPE >
+<style type="text/css">
+  body,
+  p,
+  span,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  tr,
+  td,
+  a,
+  label,
+  div,
+  button,
+  input,
+  caption,
+  input,
+  textarea,
+  legend,
+  li,
+  ol,
+  select,
+  summary,
+  table,
+  td,
+  tbody,
+  th,
+  thead,
+  ul {
+    font-family: Arial !important;
+  }</style
+><!--[if mso
+      ]><style type="text/css">
+        body,
+        table,
+        td {
+          font-family: Arial, Helvetica, sans-serif !important;
+        }
+      </style><!
+    [endif]-->
+<p>Some body</p>
+</body>
+</html>

--- a/spec/examples/malformed-style.txt
+++ b/spec/examples/malformed-style.txt
@@ -1,0 +1,1 @@
+Some body


### PR DESCRIPTION
This was previously failing with: `NoMethodError: undefined method `downcase' for nil:NilClass`