### PR TITLE
Update gemspec to allow newer version of Nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    html2text (0.3.0)
-      nokogiri (~> 1.10.3)
+    html2text (0.3.1)
+      nokogiri (>= 1.0, < 2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -12,9 +12,11 @@ GEM
       thor (~> 0.18)
     colorize (0.7.7)
     diff-lcs (1.3)
-    mini_portile2 (2.4.0)
-    nokogiri (1.10.3)
-      mini_portile2 (~> 2.4.0)
+    mini_portile2 (2.5.0)
+    nokogiri (1.11.0)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
+    racc (1.5.2)
     rake (10.4.2)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -45,4 +47,4 @@ DEPENDENCIES
   rspec-collection_matchers
 
 BUNDLED WITH
-   2.0.1
+   2.1.4

--- a/html2text.gemspec
+++ b/html2text.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*", "LICENSE.md", "README.md", "CHANGELOG.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "nokogiri", "~> 1.10.3"
+  s.add_dependency "nokogiri", ['>= 1.0', '< 2.0']
 
   s.add_development_dependency "rspec"
   s.add_development_dependency "rspec-collection_matchers"


### PR DESCRIPTION
This is preventing people using this package from updating Nokogiri to 1.11 which fixes https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:H/PR:L/UI:R/S:U/C:L/I:N/A:N