### PR TITLE
Remove unnecessary explicit receiver in Html2Text.convert

### DIFF
--- a/lib/html2text.rb
+++ b/lib/html2text.rb
@@ -25,7 +25,7 @@ class Html2Text
     html = fix_newlines(replace_entities(html))
     doc = Nokogiri::HTML(html)
 
-    Html2Text.new(doc).convert
+    new(doc).convert
   end
 
   def self.fix_newlines(text)


### PR DESCRIPTION
This makes subclassing Html2Text easier as `convert` does not have to be reimplemented.