### PR TITLE
perf: cut allocations 2x in DOM traversal for ~1.6x faster conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Require Ruby 3.3+; CI now tests Ruby 3.3, 3.4 and 4.0 ([#42](https://github.com/soundasleep/html2text_ruby/pull/42))
 - Update development dependencies (rubocop 1.88, nokogiri 1.19 in the lockfile), removing the transitive `rexml` dependency ([#42](https://github.com/soundasleep/html2text_ruby/pull/42))
+- Reduce object allocations in `iterate_over` for ~1.6x faster conversion of large documents ([#41](https://github.com/soundasleep/html2text_ruby/pull/41))
+
+### Added
+- Specs covering subclass overrides of `prefix_whitespace`, `suffix_whitespace`, `iterate_over`, `wrap_link` and `image_text`, plus unit specs for `fix_newlines` and `replace_entities` ([#41](https://github.com/soundasleep/html2text_ruby/pull/41))
 
 ## [0.4.0](https://github.com/soundasleep/html2text_ruby/compare/0.3.1...v0.4.0) - 2024-06-08
 ### Added

--- a/lib/html2text.rb
+++ b/lib/html2text.rb
@@ -50,7 +50,7 @@ class Html2Text
   end
 
   DO_NOT_TOUCH_WHITESPACE = '<do-not-touch-whitespace>'
-  IGNORED_TAGS = %w[style head title meta script].freeze
+  IGNORED_TAGS = Set.new(%w[style head title meta script]).freeze
 
   def remove_leading_and_trailing_whitespace(text)
     # ignore any <pre> blocks, which we don't want to interact with

--- a/lib/html2text.rb
+++ b/lib/html2text.rb
@@ -50,6 +50,7 @@ class Html2Text
   end
 
   DO_NOT_TOUCH_WHITESPACE = '<do-not-touch-whitespace>'
+  IGNORED_TAGS = %w[style head title meta script].freeze
 
   def remove_leading_and_trailing_whitespace(text)
     # ignore any <pre> blocks, which we don't want to interact with
@@ -74,14 +75,14 @@ class Html2Text
   private
 
   def remove_unnecessary_empty_lines(text)
-    text.gsub(/\n\n\n*/im, "\n\n")
+    text.gsub(/\n{3,}/, "\n\n")
   end
 
   def trimmed_whitespace(text)
     # Replace whitespace characters with a space (equivalent to \s)
     # and force any text encoding into UTF-8
     if text.valid_encoding?
-      text.gsub(/[\t\n\f\r ]+/im, ' ')
+      text.gsub(/[\t\n\f\r ]+/, ' ')
     else
       text.force_encoding('WINDOWS-1252')
       trimmed_whitespace(text.encode('UTF-16be', invalid: :replace, replace: '?').encode('UTF-8'))
@@ -89,45 +90,36 @@ class Html2Text
   end
 
   def iterate_over(node)
-    return "\n" if node.name.downcase == 'br' && next_node_is_text?(node)
-
     return trimmed_whitespace(node.text) if node.text?
 
-    return '' if %w[style head title meta script].include?(node.name.downcase)
+    name = node.name&.downcase
 
-    return "\n#{DO_NOT_TOUCH_WHITESPACE}#{node.text}#{DO_NOT_TOUCH_WHITESPACE}" if node.name.downcase == 'pre'
+    return '' if name.nil? || IGNORED_TAGS.include?(name)
 
-    output = []
+    return "\n" if name == 'br' && next_node_is_text?(node)
 
-    output << prefix_whitespace(node)
-    output += node.children.map do |child|
-      iterate_over(child) unless child.name.nil?
+    return "\n#{DO_NOT_TOUCH_WHITESPACE}#{node.text}#{DO_NOT_TOUCH_WHITESPACE}" if name == 'pre'
+
+    return image_text(node) if name == 'img'
+
+    output = +''
+    output << (prefix_whitespace(node) || '')
+    node.children.each do |child|
+      output << iterate_over(child)
     end
-    output << suffix_whitespace(node)
+    output << (suffix_whitespace(node) || '')
 
-    output = output.compact.join || ''
-
-    unless node.name.nil?
-      if node.name.downcase == 'a'
-        output = wrap_link(node, output)
-      elsif node.name.downcase == 'img'
-        output = image_text(node)
-      end
-    end
+    output = wrap_link(node, output) if name == 'a'
 
     output
   end
 
-  # rubocop:disable Lint/DuplicateBranch
   def prefix_whitespace(node)
     case node.name.downcase
     when 'hr'
       "\n---------------------------------------------------------------\n"
 
-    when 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'ol', 'ul'
-      "\n\n"
-
-    when 'p'
+    when 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'ol', 'ul', 'p'
       "\n\n"
 
     when 'tr'
@@ -147,20 +139,15 @@ class Html2Text
       '- '
     end
   end
-  # rubocop:enable Lint/DuplicateBranch
 
-  # rubocop:disable Lint/DuplicateBranch
   def suffix_whitespace(node)
     case node.name.downcase
-    when 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'
-      # add another line
-      "\n\n"
-
-    when 'p'
+    when 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p'
       "\n\n"
 
     when 'br'
-      "\n" if next_node_name(node) != 'div' && !next_node_name(node).nil?
+      next_name = next_node_name(node)
+      "\n" if !next_name.nil? && next_name != 'div'
 
     when 'li'
       "\n"
@@ -168,12 +155,12 @@ class Html2Text
     when 'div'
       if next_node_is_text?(node)
         "\n"
-      elsif next_node_name(node) != 'div' && !next_node_name(node).nil?
-        "\n"
+      else
+        next_name = next_node_name(node)
+        "\n" if !next_name.nil? && next_name != 'div'
       end
     end
   end
-  # rubocop:enable Lint/DuplicateBranch
 
   # links are returned in [text](link) format
   def wrap_link(node, output)

--- a/spec/class_methods_spec.rb
+++ b/spec/class_methods_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Html2Text do
+  describe '.fix_newlines' do
+    it 'converts \r\n to \n' do
+      expect(Html2Text.fix_newlines("hello\r\nworld")).to eq("hello\nworld")
+    end
+
+    it 'converts bare \r to \n' do
+      expect(Html2Text.fix_newlines("hello\rworld")).to eq("hello\nworld")
+    end
+  end
+
+  describe '.replace_entities' do
+    it 'replaces &nbsp; entities with spaces' do
+      expect(Html2Text.replace_entities('hello&nbsp;world')).to eq('hello world')
+    end
+
+    it 'replaces non-breaking space characters with spaces' do
+      expect(Html2Text.replace_entities("hello\u00a0world")).to eq('hello world')
+    end
+
+    it 'removes zero-width non-joiners' do
+      expect(Html2Text.replace_entities('hello&zwnj;world')).to eq('helloworld')
+    end
+  end
+end

--- a/spec/subclass_spec.rb
+++ b/spec/subclass_spec.rb
@@ -22,6 +22,16 @@ class CustomLinkFormat < Html2Text
   end
 end
 
+class CustomListSuffix < Html2Text
+  private
+
+  def suffix_whitespace(node)
+    return ";\n" if node.name.downcase == 'li'
+
+    super
+  end
+end
+
 class SkipsBlockquotes < Html2Text
   private
 
@@ -49,6 +59,11 @@ describe 'subclassing Html2Text' do
   it 'can override wrap_link' do
     text = CustomLinkFormat.convert('<a href="http://example.com">hello</a>')
     expect(text).to eq('hello <http://example.com>')
+  end
+
+  it 'can override suffix_whitespace' do
+    text = CustomListSuffix.convert('<ul><li>one</li><li>two</li></ul>')
+    expect(text).to eq("- one;\n- two;")
   end
 
   it 'can override iterate_over' do

--- a/spec/subclass_spec.rb
+++ b/spec/subclass_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Subclassing Html2Text to override the default behaviour is supported
+# (see #30); these specs pin the extension points that subclasses rely on.
+class CustomListPrefix < Html2Text
+  private
+
+  def prefix_whitespace(node)
+    return '* ' if node.name.downcase == 'li'
+
+    super
+  end
+end
+
+class CustomLinkFormat < Html2Text
+  private
+
+  def wrap_link(node, output)
+    "#{output.strip} <#{node.attribute('href')}>"
+  end
+end
+
+class SkipsBlockquotes < Html2Text
+  private
+
+  def iterate_over(node)
+    return '' if !node.text? && node.name.downcase == 'blockquote'
+
+    super
+  end
+end
+
+class CustomImageText < Html2Text
+  private
+
+  def image_text(node)
+    "(image: #{node.attribute('src')})"
+  end
+end
+
+describe 'subclassing Html2Text' do
+  it 'can override prefix_whitespace' do
+    text = CustomListPrefix.convert('<ul><li>one</li><li>two</li></ul>')
+    expect(text).to eq("* one\n* two")
+  end
+
+  it 'can override wrap_link' do
+    text = CustomLinkFormat.convert('<a href="http://example.com">hello</a>')
+    expect(text).to eq('hello <http://example.com>')
+  end
+
+  it 'can override iterate_over' do
+    text = SkipsBlockquotes.convert('<p>before</p><blockquote>quoted</blockquote><p>after</p>')
+    expect(text).to eq("before\n\nafter")
+  end
+
+  it 'can override image_text' do
+    text = CustomImageText.convert('<img src="pic.png" alt="a picture">')
+    expect(text).to eq('(image: pic.png)')
+  end
+
+  it 'uses the subclass from self.convert' do
+    expect(CustomListPrefix.convert('plain text')).to eq('plain text')
+  end
+end


### PR DESCRIPTION
## Summary

Profiling `Html2Text.convert` (stackprof, wall + object modes) against this repo's own `huge-msoffice.html` fixture (1.4MB) showed:

- **GC was 41% of wall time**, driven by **1.37M object allocations** for a single convert
- 573K allocations (42%) came from `String#downcase` and 375K (27%) from `Nokogiri::XML::Node#node_name` — `node.name.downcase` was being recomputed ~19 times per node across `iterate_over`, `prefix_whitespace`, `suffix_whitespace` and `next_node_name`
- another ~120K came from the per-node `Array` → `map` → `compact` → `join` in `iterate_over`, which also re-copies each subtree's text at every tree level

## Changes

All behavior-preserving — output is **byte-identical on every fixture in `spec/examples/`** (verified by a side-by-side harness during development, and the full suite passes unchanged):

- `iterate_over` computes `node.name.downcase` once per node and reuses it for all checks
- children are appended into a single mutable string instead of building an array and joining per node
- `suffix_whitespace` calls `next_node_name` once instead of twice for `br`/`div`
- merged the duplicate `h1`-`h6`/`p` case branches, removing the `Lint/DuplicateBranch` disables
- dropped no-op `/im` regex flags and simplified `/\n\n\n*/` to `/\n{3,}/`

Method signatures and return types are deliberately unchanged, so subclasses that override `prefix_whitespace`, `suffix_whitespace`, `iterate_over`, `wrap_link` or `image_text` (supported since #30) are unaffected.

## Benchmarks

Ruby 4.0.5, arm64 macOS, fixtures from `spec/examples/`, with and without YJIT (50-iteration warmup so YJIT compiles the hot paths):

| Benchmark | master | this PR | improvement |
|---|---|---|---|
| huge-msoffice (1.4MB) ×5, no JIT | 0.893s | 0.545s | **1.64x** |
| huge-msoffice (1.4MB) ×5, YJIT | 0.648s | 0.469s | **1.38x** |
| full_email (15KB) ×500, no JIT | 0.351s | 0.280s | **1.25x** |
| full_email (15KB) ×500, YJIT | 0.317s | 0.248s | **1.28x** |
| allocations, 1 convert of 1.4MB | 1,367,401 | 642,896 | **2.1x fewer** |

YJIT narrows the large-document gap somewhat (it cheapens the redundant method calls) but can't eliminate object allocations — allocation counts are identical with and without YJIT, and GC pressure was the dominant cost, so the win holds up under YJIT. The allocation reduction also lowers GC pressure process-wide for apps converting many documents.

## New tests

- `spec/subclass_spec.rb` — pins the subclass extension points (`prefix_whitespace`, `wrap_link`, `iterate_over`, `image_text`, and `self.convert` dispatch), which were previously untested despite being an advertised feature
- `spec/class_methods_spec.rb` — unit specs for `fix_newlines` and `replace_entities`

All new tests were verified to pass against the **old** implementation as well (run in a clean master worktree), so they pin pre-existing behavior rather than new behavior. 64 examples, 0 failures; rubocop clean.

## Not changed (noted for the record)

The `div` handling in `prefix_whitespace` compares `node.parent.text.strip == node.text.strip`, which serializes both subtrees for every nested div — O(n²) in the worst case. Stress tests with quote-chains up to depth 800 stayed fast in absolute terms, so it's left alone here; fixing it would need a structural check with subtle output-semantics risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
